### PR TITLE
Fix zip tuple docs

### DIFF
--- a/docs/source/tuples.md
+++ b/docs/source/tuples.md
@@ -19,7 +19,7 @@ def tuple_zip(*args):
 
 @overload(tuple_zip)
 def tuple_zip_ovrl(*args):
-    return tuple_zip_intr
+    return lambda *args: tuple_zip_intr(*args)
 
 @intrinsic
 def tuple_zip_intr(tyctx, *tys):


### PR DESCRIPTION
Change the code zip tuples example to return a lambda rather than a raw intrinsic, which is now allowed.

See https://github.com/numba/numba/issues/8806